### PR TITLE
Add robot position argument

### DIFF
--- a/ur_robot_driver/launch/ur5e_bringup.launch
+++ b/ur_robot_driver/launch/ur5e_bringup.launch
@@ -3,6 +3,7 @@
   <arg name="robot_name" default="robot" />
   <arg name="gripper_type" default="gripper" />
   <arg name="finger_type" default="finger" />
+  <arg name="robot_pos_file" default="" />
 
   <arg name="debug" default="false" doc="Debug flag that will get passed on to ur_common.launch"/>
   <arg name="robot_ip" doc="IP address by which the robot can be reached."/>

--- a/ur_robot_driver/launch/ur_common.launch
+++ b/ur_robot_driver/launch/ur_common.launch
@@ -3,6 +3,7 @@
   <arg name="robot_name" default="robot" />
   <arg name="gripper_type" default="gripper" />
   <arg name="finger_type" default="finger" />
+  <arg name="robot_pos_file" default="" />
 
   <arg name="debug" default="false" doc="Debug flag that will get passed on to ur_control.launch"/>
   <arg name="use_tool_communication" doc="On e-Series robots tool communication can be enabled with this argument"/>
@@ -34,6 +35,7 @@
     <arg name="robot_name" value="$(arg robot_name)" />
     <arg name="gripper_type" value="$(arg gripper_type)" />
     <arg name="finger_type" value="$(arg finger_type)" />
+    <arg name="robot_pos_file" value="$(arg robot_pos_file)" />
   </include>
 
   <!-- Convert joint states to /tf tranforms -->


### PR DESCRIPTION
# DONT MERGE

This PR is adding and argument to be passed between the docker-compose of the ur5 and the `robot_description`.
This new argument `robot_pos_file` store a link to the config file that defines the transform between the robot_base and the world link. This allows the robot to be spawned with the calibrated transform w.r.t the other robots. 

This new feature has been implemented in the following PR in the project: [Shokunin description xacro changes](https://github.com/SonyResearch/project_shokunin/pull/957)